### PR TITLE
feat: Make Inheritance option

### DIFF
--- a/annotation-processor/src/main/java/io/fixentropy/processor/DrageeProfile.java
+++ b/annotation-processor/src/main/java/io/fixentropy/processor/DrageeProfile.java
@@ -26,11 +26,19 @@ class DrageeProfile {
     }
 
     public boolean isPresentOrInheritedOn(Element element, Types types) {
-        Set<Element> inheritedElements = inheritedElements(element.asType(), types);
+        Set<Element> inheritedElements = inheritedElements(element, types);
         Set<Element> allAnnotationsOnElement = inheritedAnnotations(inheritedElements);
 
         return allAnnotationsOnElement.stream()
                 .anyMatch(this.type::isBasedOn);
+    }
+
+    private Set<Element> inheritedElements(Element element, Types types) {
+        if (this.type.isInheritable()) {
+            return inheritedElements(element.asType(), types);
+        }
+
+        return Set.of(element);
     }
 
     private Set<Element> inheritedElements(TypeMirror typeMirror, Types types) {

--- a/annotation-processor/src/main/java/io/fixentropy/processor/DrageeType.java
+++ b/annotation-processor/src/main/java/io/fixentropy/processor/DrageeType.java
@@ -1,5 +1,6 @@
 package io.fixentropy.processor;
 
+import io.fixentropy.annotation.Inheritable;
 import io.fixentropy.util.SimpleName;
 
 import javax.lang.model.element.Element;
@@ -28,5 +29,9 @@ public class DrageeType {
 
     public static DrageeType from(TypeElement element) {
         return new DrageeType(element);
+    }
+
+    public boolean isInheritable() {
+        return this.element.getAnnotation(Inheritable.class) != null;
     }
 }

--- a/annotation-processor/src/main/java/io/fixentropy/testing/Compiler.java
+++ b/annotation-processor/src/main/java/io/fixentropy/testing/Compiler.java
@@ -78,7 +78,8 @@ public class Compiler {
 
         private boolean success;
 
-        private Result() {}
+        private Result() {
+        }
 
         public boolean success() {
             return success;
@@ -91,6 +92,11 @@ public class Compiler {
             } catch (IOException e) {
                 throw new RuntimeException(String.format("Failed to read dragee file '%s'", relativePath), e);
             }
+        }
+
+        public boolean hasDrageeFile(Path relativePath) {
+            Path drageePath = DRAGEE_FOLDER.resolve(relativePath);
+            return Files.exists(drageePath);
         }
 
         private Result execute() {

--- a/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/GrandParent.java
+++ b/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/GrandParent.java
@@ -1,7 +1,7 @@
 package io.fixentropy.rules.object_inheritance;
 
-import io.fixentropy.testing.TypeOne;
+import io.fixentropy.testing.InheritableType;
 
-@TypeOne
+@InheritableType
 public interface GrandParent {
 }

--- a/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/ObjectInheritanceTest.java
+++ b/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/ObjectInheritanceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Path;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ObjectInheritanceTest {
 
@@ -16,25 +17,43 @@ public class ObjectInheritanceTest {
         Compiler compiler = Compiler.compileTestClasses(
                 SOURCE_FOLDER.resolve("GrandParent.java"),
                 SOURCE_FOLDER.resolve("Parent.java"),
-                SOURCE_FOLDER.resolve("Child.java")
-        );
+                SOURCE_FOLDER.resolve("Child.java"),
+                SOURCE_FOLDER.resolve("SecondGrandParent.java"),
+                SOURCE_FOLDER.resolve("SecondParent.java"),
+                SOURCE_FOLDER.resolve("SecondChild.java"));
 
         return compiler.executeProcessor();
     }
 
-    private static String contentOfDragee(Compiler.Result actualResult) {
-        return actualResult.readDrageeFile(OUTPUT_FOLDER.resolve("Child.json"));
+    private static String contentOfDragee(Compiler.Result actualResult, String expectedFileName) {
+        return actualResult.readDrageeFile(OUTPUT_FOLDER.resolve(expectedFileName));
     }
 
     @Test
     void profile_dragee_can_be_inherited() {
         Compiler.Result actualResult = executeProcessor();
 
-        String actualContent = contentOfDragee(actualResult);
+        String actualContent = contentOfDragee(actualResult, "Child.json");
+
+        assertThatJson(actualContent)
+                .inPath("$.profile")
+                .isEqualTo("testing/inheritable_type");
+
+        assertThat(actualResult.hasDrageeFile(OUTPUT_FOLDER.resolve("GrandParent.json"))).isTrue();
+        assertThat(actualResult.hasDrageeFile(OUTPUT_FOLDER.resolve("Parent.json"))).isTrue();
+    }
+
+    @Test
+    void profile_dragee_is_not_inherited() {
+        Compiler.Result actualResult = executeProcessor();
+
+        String actualContent = contentOfDragee(actualResult, "SecondGrandParent.json");
 
         assertThatJson(actualContent)
                 .inPath("$.profile")
                 .isEqualTo("testing/type_one");
-    }
 
+        assertThat(actualResult.hasDrageeFile(OUTPUT_FOLDER.resolve("SecondParent.json"))).isFalse();
+        assertThat(actualResult.hasDrageeFile(OUTPUT_FOLDER.resolve("SecondChild.json"))).isFalse();
+    }
 }

--- a/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondChild.java
+++ b/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondChild.java
@@ -1,0 +1,4 @@
+package io.fixentropy.rules.object_inheritance;
+
+public class SecondChild extends SecondParent {
+}

--- a/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondGrandParent.java
+++ b/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondGrandParent.java
@@ -1,0 +1,7 @@
+package io.fixentropy.rules.object_inheritance;
+
+import io.fixentropy.testing.TypeOne;
+
+@TypeOne
+public interface SecondGrandParent {
+}

--- a/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondParent.java
+++ b/annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondParent.java
@@ -1,0 +1,4 @@
+package io.fixentropy.rules.object_inheritance;
+
+public class SecondParent implements SecondGrandParent {
+}

--- a/annotation-processor/src/test/java/io/fixentropy/testing/InheritableType.java
+++ b/annotation-processor/src/test/java/io/fixentropy/testing/InheritableType.java
@@ -1,0 +1,15 @@
+package io.fixentropy.testing;
+
+import io.fixentropy.annotation.Inheritable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Testing
+@Inheritable
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.SOURCE)
+public @interface InheritableType {
+}

--- a/core-annotations/src/main/java/io/fixentropy/annotation/Inheritable.java
+++ b/core-annotations/src/main/java/io/fixentropy/annotation/Inheritable.java
@@ -1,0 +1,13 @@
+package io.fixentropy.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Indicates that an annotation should be inherited by subclasses.
+ */
+@Documented
+@Inherited
+@Target({ ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.CLASS)
+public @interface Inheritable {
+}


### PR DESCRIPTION
This pull request introduces support for inheritable annotations in the annotation processor, allowing certain annotation profiles to be inherited through class hierarchies when marked as inheritable. It also adds comprehensive tests to verify both inheritable and non-inheritable behaviors.

### Annotation Inheritance Support

* Added the `Inheritable` annotation in `core-annotations`, which can be used to mark other annotations as inheritable. (`core-annotations/src/main/java/io/fixentropy/annotation/Inheritable.java`)
* Updated the `DrageeType` class to detect if an annotation is inheritable by checking for the `Inheritable` annotation, and exposed this via the new `isInheritable()` method. (`annotation-processor/src/main/java/io/fixentropy/processor/DrageeType.java`)
* Modified the `DrageeProfile` logic to use the new inheritance check, so that inherited elements are only considered if the annotation is inheritable. (`annotation-processor/src/main/java/io/fixentropy/processor/DrageeProfile.java`)

### Testing Enhancements

* Added the `InheritableType` annotation for testing inheritable annotation behavior, and updated test sources to use it. (`annotation-processor/src/test/java/io/fixentropy/testing/InheritableType.java`, `annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/GrandParent.java`) [[1]](diffhunk://#diff-a2c02337f19826de807d2476d2410ccf4d1cc4cc681657d971b8e981fe872314R1-R15) [[2]](diffhunk://#diff-e703a96cc462b749188f01db45c84464ef3255a95e3975ee054ef18d44377f14L3-R5)
* Expanded the `ObjectInheritanceTest` suite to cover both inheritable and non-inheritable annotation scenarios, including new test classes for each case and additional assertions on file generation. (`annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/ObjectInheritanceTest.java`, `annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondGrandParent.java`, `annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondParent.java`, `annotation-processor/src/test/java/io/fixentropy/rules/object_inheritance/SecondChild.java`) [[1]](diffhunk://#diff-cdea295253f12edfb13fc0d42802772fb530e9700bc23ddc268e393e5f6c56e2L19-R58) [[2]](diffhunk://#diff-955d276472ca8bca4d7e55d010ac70ba50ea1b57c4b9e612ba103612452ccc75R1-R7) [[3]](diffhunk://#diff-5ec450297427df6b652dfcd5ab44dd6bb34c8f5df418712c01fc62374496fd43R1-R4) [[4]](diffhunk://#diff-74dd982497e3e7ab25cda303bb6640e9e79fc10fe95b850852205c9630f6bfa1R1-R4)

### Test Utility Improvements

* Added a method to check for the existence of generated files in the `Compiler.Result` class, improving test assertions. (`annotation-processor/src/main/java/io/fixentropy/testing/Compiler.java`)